### PR TITLE
Add isActive field check for monitor.queries repository call.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/repository/MonitorRepository.java
+++ b/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/repository/MonitorRepository.java
@@ -6,6 +6,6 @@ import uk.gov.companieshouse.monitorsubscription.matcher.repository.model.Monito
 
 public interface MonitorRepository extends MongoRepository<MonitorQueryDocument, String> {
 
-    List<MonitorQueryDocument> findByCompanyNumber(String companyNumber);
+    List<MonitorQueryDocument> findByCompanyNumberAndIsActive(String companyNumber, Boolean isActive);
 
 }

--- a/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/service/MatcherService.java
@@ -51,15 +51,17 @@ public class MatcherService {
         }
 
         // Query the repository for matching companies.
-        List<MonitorQueryDocument> companies = repository.findByCompanyNumber(message.getCompanyNumber());
+        List<MonitorQueryDocument> companies = repository.findByCompanyNumberAndIsActive(message.getCompanyNumber(), true);
         logger.debug("Found %d matching companies".formatted(companies.size()));
 
-        // Process each query document and prepare messages for the producer.
-        companies.stream().map(MonitorQueryDocument::getUserId).forEach(userId -> {
-            Message<filing> messageToSend = converter.apply(message, userId);
+        // Process each query document and prepare messages for the producer - only if companies list not empty.
+        if (!companies.isEmpty()) {
+            companies.stream().map(MonitorQueryDocument::getUserId).forEach(userId -> {
+                Message<filing> messageToSend = converter.apply(message, userId);
 
-            producer.sendMessage(messageToSend);
-        });
+                producer.sendMessage(messageToSend);
+            });
+        }
     }
 
     private Optional<String> getTransactionId(final transaction message) {

--- a/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/companieshouse/monitorsubscription/matcher/service/MatcherService.java
@@ -54,14 +54,12 @@ public class MatcherService {
         List<MonitorQueryDocument> companies = repository.findByCompanyNumberAndIsActive(message.getCompanyNumber(), true);
         logger.debug("Found %d matching companies".formatted(companies.size()));
 
-        // Process each query document and prepare messages for the producer - only if companies list not empty.
-        if (!companies.isEmpty()) {
-            companies.stream().map(MonitorQueryDocument::getUserId).forEach(userId -> {
-                Message<filing> messageToSend = converter.apply(message, userId);
+        // Process each query document and prepare messages for the producer
+        companies.stream().map(MonitorQueryDocument::getUserId).forEach(userId -> {
+            Message<filing> messageToSend = converter.apply(message, userId);
 
-                producer.sendMessage(messageToSend);
-            });
-        }
+            producer.sendMessage(messageToSend);
+        });
     }
 
     private Optional<String> getTransactionId(final transaction message) {

--- a/src/test/java/uk/gov/companieshouse/monitorsubscription/matcher/repository/MonitorRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/monitorsubscription/matcher/repository/MonitorRepositoryTest.java
@@ -3,10 +3,12 @@ package uk.gov.companieshouse.monitorsubscription.matcher.repository;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.ACTIVE;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.COMPANY_NUMBER;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.CREATED_DATE;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.ID;
+import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.INACTIVE;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.QUERY;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.MonitorFilingTestUtils.UPDATED_DATE;
 import static uk.gov.companieshouse.monitorsubscription.matcher.util.NotificationMatchTestUtils.USER_ID;
@@ -50,7 +52,7 @@ public class MonitorRepositoryTest {
 
         underTest.save(document);
 
-        List<MonitorQueryDocument> results = underTest.findByCompanyNumber(document.getCompanyNumber());
+        List<MonitorQueryDocument> results = underTest.findByCompanyNumberAndIsActive(document.getCompanyNumber(), true);
 
         assertThat(results, is(notNullValue()));
         assertThat(results.size(), is(1));
@@ -62,5 +64,22 @@ public class MonitorRepositoryTest {
         assertThat(UPDATED_DATE, is(results.getFirst().getUpdatedAt()));
         assertThat(QUERY, is(results.getFirst().getQuery()));
         assertThat(USER_ID, is(results.getFirst().getUserId()));
+    }
+
+        @Test
+    void givenQueryDocument_whenDocumentSavedAndIsInActive_thenDocumentIgnoredSuccessfully() {
+        MonitorQueryDocument document = new MonitorQueryDocument();
+        document.setId(ID);
+        document.setCompanyNumber(COMPANY_NUMBER);
+        document.setCreatedAt(CREATED_DATE);
+        document.setActive(INACTIVE);
+        document.setUpdatedAt(UPDATED_DATE);
+        document.setQuery(QUERY);
+        document.setUserId(USER_ID);    
+
+        underTest.save(document);
+
+        List<MonitorQueryDocument> results = underTest.findByCompanyNumberAndIsActive(document.getCompanyNumber(), true);
+        assertThat(results.size(), is(0));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/monitorsubscription/matcher/util/MonitorFilingTestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/monitorsubscription/matcher/util/MonitorFilingTestUtils.java
@@ -17,6 +17,7 @@ public class MonitorFilingTestUtils {
     public static final String COMPANY_NUMBER = "00006400";
     public static final LocalDateTime CREATED_DATE = LocalDateTime.parse("2023-10-10T10:00:00");
     public static final Boolean ACTIVE = Boolean.TRUE;
+    public static final Boolean INACTIVE = Boolean.FALSE;
     public static final LocalDateTime UPDATED_DATE = CREATED_DATE.plusDays(1);
     public static final String QUERY = "QUERY transaction WHERE company_number=\"%s\"".formatted(COMPANY_NUMBER);
     public static final String PUBLISHED_AT = "2025-03-03T15:04:03";


### PR DESCRIPTION
## Describe the changes
Checks the `isActive` flag is `true` before adding to list of users following a company.

### Related Jira tickets
[Jira Ticket](https://companieshouse.atlassian.net/browse/KAF-163)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on docker-chs-development?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._
